### PR TITLE
Solve #135

### DIFF
--- a/pyffmpeg/pseudo_ffprobe.py
+++ b/pyffmpeg/pseudo_ffprobe.py
@@ -229,7 +229,7 @@ class FFprobe():
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            shell=True)
+            shell=False)
 
         # break the operation
         sleep(0.02)


### PR DESCRIPTION
https://github.com/deuteronomy-works/pyffmpeg/issues/135

Changed shell parameter to False in subprocess.Popen to accept a path-like object
https://docs.python.org/3/library/subprocess.html#popen-constructor