### PR TITLE
Simplify probe

### DIFF
--- a/pyffmpeg/pseudo_ffprobe.py
+++ b/pyffmpeg/pseudo_ffprobe.py
@@ -228,7 +228,7 @@ class FFprobe():
 
         # randomize the filename to avoid overwrite prompt
 
-        commands = [self._ffmpeg, '-i', self.file_name, "-f", "null", os.devnull]
+        commands = [self._ffmpeg, '-y', '-i', self.file_name, "-f", "null", os.devnull]
 
         # start subprocess
         subP = subprocess.Popen(

--- a/pyffmpeg/pseudo_ffprobe.py
+++ b/pyffmpeg/pseudo_ffprobe.py
@@ -227,9 +227,8 @@ class FFprobe():
     def probe(self):
 
         # randomize the filename to avoid overwrite prompt
-        out_file = str(random.randrange(1, 10000000)) + '.mp3'
 
-        commands = [self._ffmpeg, '-i', self.file_name, out_file]
+        commands = [self._ffmpeg, '-i', self.file_name, "-f", "null", os.devnull]
 
         # start subprocess
         subP = subprocess.Popen(
@@ -237,16 +236,14 @@ class FFprobe():
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            text=True,
             shell=SHELL)
 
         # break the operation
         sleep(0.02)
-        stdout, _ = subP.communicate(input=b'q')
+        stdout, _ = subP.communicate(input='q')
 
-        if os.path.exists(out_file):
-            os.unlink(out_file)
-
-        self._extract_all(str(stdout, 'utf-8'))
+        self._extract_all(stdout)
 
         # Expose publicly know var
         self._expose()

--- a/pyffmpeg/pseudo_ffprobe.py
+++ b/pyffmpeg/pseudo_ffprobe.py
@@ -228,7 +228,7 @@ class FFprobe():
 
         # randomize the filename to avoid overwrite prompt
 
-        commands = [self._ffmpeg, '-y', '-i', self.file_name, "-f", "null", os.devnull]
+        commands = [self._ffmpeg, '-y', '-i', self.file_name, '-f', 'null', os.devnull]
 
         # start subprocess
         subP = subprocess.Popen(

--- a/tests/test_pseudo_ffprobe.py
+++ b/tests/test_pseudo_ffprobe.py
@@ -1,11 +1,13 @@
-
+import pytest
+from pyffmpeg import FFprobe
 # test speed to make sure no convertion took place
 # test file exist does not happen
-# from pyffmpeg import FFprobe
-
+TEST_FILES = {"tests/countdown.mp4", "tests/Easy_Lemon_30_Second_-_Kevin_MacLeod.mp3", "tests/Ecossaise in E-flat - Kevin MacLeod.mp3"}
 
 def test_probe():
-    pass
+    for file in TEST_FILES:
+        ffp = FFprobe(file)
+        ffp.probe()
 
 
 def test_album_art():


### PR DESCRIPTION
I simplified FFprobe's probe() call.

Now the `subprocess.Popen()` call to ffmpeg uses the null format so there is no output file we have to clean up afterwards. The subprocess call also takes `text=True` so we can send a literal 'q' to the process and take the stdout without having to cast to string. 

I also integrated some simple tests to verify that probe() doesn't crash on the test files.