### PR TITLE
Update FFProbe tag retrieval 

### DIFF
--- a/local_probe_t_est.py
+++ b/local_probe_t_est.py
@@ -1,4 +1,5 @@
 import os
+import pprint
 from pyffmpeg import FFprobe
 
 
@@ -8,15 +9,16 @@ test_file = os.path.join(test_folder, 'Easy_Lemon_30_Second_-_Kevin_MacLeod.mp3'
 #test_file = "G:\Entertainment\Movies\Interstellar (2014)\Interstellar.2014.720p.BluRay.x264.YIFY.mp4"
 flv_file = os.path.join(test_folder, 'sample_960x400_ocean_with_audio.flv')
 
-f = FFprobe('flv_file')
+f = FFprobe(flv_file)
 # ret = f.get_album_art('cover.png')
 
 
-print(f.duration)
+pprint.pprint(f.duration)
 for x in f.metadata:
     print(x, '\n')
 
-print(f.metadata)
-print(f.metadata[0])
+pprint.pprint(f.metadata)
+pprint.pprint(f.metadata[0])
 # print(f.metadata[0][0])
-print(f.metadata[0][0]['codec'])
+print("is codec flv1?")
+pprint.pprint(f.metadata[0]['codec'] == 'flv1')

--- a/pyffmpeg/__init__.py
+++ b/pyffmpeg/__init__.py
@@ -139,14 +139,17 @@ class FFmpeg():
             self._in_duration = float(d)
             self.monitor(out)
 
-        outP = Popen(
-            options, shell=SHELL, stdin=PIPE,
-            stdout=PIPE, stderr=PIPE
-            )
-        self._ffmpeg_instances['convert'] = outP
-        stderr = str(outP.stderr.read(), 'utf-8')
+        try:
+            outP = Popen(
+                options, shell=SHELL, stdin=PIPE,
+                stdout=PIPE, stderr=PIPE
+                )
+            self._ffmpeg_instances['convert'] = outP
+            stderr = str(outP.stderr.read(), 'utf-8')
 
-        print(stderr)
+            print(stderr)
+        except:
+            self.quit()
 
         if 'Output #0' not in stderr:
             lines = stderr.splitlines()
@@ -272,9 +275,13 @@ class FFmpeg():
         if not SHELL:
             options = shlex.split(options, posix=False)
 
-        out = Popen(options, shell=SHELL, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-        self._ffmpeg_instances['options'] = out
-        stderr = str(out.stderr.read(), 'utf-8')
+        try:
+            out = Popen(options, shell=SHELL, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+            self._ffmpeg_instances['options'] = out
+            stderr = str(out.stderr.read(), 'utf-8')
+        except:
+            self.quit()
+
         if stderr and 'Output #0' not in stderr:
             lines = stderr.splitlines()
             if len(lines) > 0:

--- a/test_pseudo_ffprobe.py
+++ b/test_pseudo_ffprobe.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 import requests
+from collections import defaultdict
 from pyffmpeg import FFprobe
 
 # test speed to make sure no convertion took place
@@ -31,3 +32,79 @@ def test_probe(file_name, duration):
 
 def test_album_art():
     pass
+
+@pytest.mark.parametrize(
+    'file_name',
+    [
+        ("countdown.mp4"),
+    ]
+)
+def test_generate_tags(file_name):
+    metadata_one = [
+        '    major_brand     : mp42',
+        '    minor_version   : 0',
+        '    compatible_brands: isommp42',
+        '    creation_time   : 2016-07-05T17:50:46.000000Z',
+        '  Duration: 00:00:04.37',
+        'start: 0.000000',
+        'bitrate: 322 kb/s'
+        ]
+    metadata_two = [
+        'codec: h264',
+        'data_rate: 223 kb/s',
+        'dimensions: 640x360',
+        'DAR: 16:9',
+        'SAR: 1:1',
+        'fps: 29.97',
+        'tbn: 30k',
+        'tbr: 29.97',
+        '      handler_name    : VideoHandler',
+        '      vendor_id       : [0][0][0][0]',
+        'codec: aac',
+        'bitrate: 96 kb/s',
+        'channels: stereo',
+        'sample_rate: 44100 Hz',
+        '      creation_time   : 2016-07-05T17:50:46.000000Z',
+        '      handler_name    : IsoMedia File Produced by Google, 5-11-2011',
+        '      vendor_id       : [0][0][0][0]',
+        'Parsing a group of options: output url /dev/null.',
+        'Opening an output file: /dev/null.',
+        '[h264 @ 0x7f916e046480] nal_unit_type: 7(SPS), nal_ref_idc: 3',
+        '[h264 @ 0x7f916e046480] nal_unit_type: 8(PPS), nal_ref_idc: 3'
+        ]   
+    tags_one = defaultdict(list,
+        {
+            'Duration': '00:00:04.37',
+            'bitrate': '322 kb/s',
+            'compatible_brands': 'isommp42',
+            'creation_time': '2016-07-05T17:50:46.000000Z',
+            'major_brand': 'mp42',
+            'minor_version': '0',
+            'start': '0.000000'
+        })
+    tags_two = defaultdict(list, 
+        {
+            'DAR': '16:9',
+            'Opening an output file': '/dev/null.',
+            'Parsing a group of options': 'output url /dev/null.',
+            'SAR': '1:1',
+            '[h264 @ 0x7f916e046480] nal_unit_type': '8(PPS), nal_ref_idc: '
+                                                        '3',
+            'bitrate': '96 kb/s',
+            'channels': 'stereo',
+            'codec': 'aac',
+            'creation_time': '2016-07-05T17:50:46.000000Z',
+            'data_rate': '223 kb/s',
+            'dimensions': '640x360',
+            'fps': '29.97',
+            'handler_name': 'IsoMedia File Produced by Google, 5-11-2011',
+            'sample_rate': '44100 Hz',
+            'tbn': '30k',
+            'tbr': '29.97',
+            'vendor_id': '[0][0][0][0]'
+        })    
+    test_file = os.path.join(TEST_FOLDER, file_name)
+    f = FFprobe(test_file)
+
+    assert tags_one == f._generate_tags(metadata_one)
+    assert tags_two == f._generate_tags(metadata_two)


### PR DESCRIPTION
Overview
-------
This code change involves a restructure related to how `FFprobe` parses metadata into tags. This is related to [issue 658](https://github.com/deuteronomy-works/pyffmpeg/issues/658), where given a video that does not comply fully with the parser it fails to add values to an empty key `''` in the dictionary.  This also condenses duplicate code previously in `_parse_input_meta` and `_parse_meta`. 

Expected behavior
--------
Return a `FFprobe` object when instantiated
```python
from pyffmpeg import FFprobe
fp = FFprobe('video.mp4')
```

Actual behavior
---------
```
    178 # this might be a continuation
    179 if key == '':
--> 180     tags[prev_key] += "\\r\\n" + data[1].strip()
    181 else:
    182     tags[key] = value

KeyError: ''
```

Reproducing Issue
---------
Steps to reproduce original issue is an extension of #658 where if you add print statements inside of the for loop of `_parse_meta` there exist keys that are empty strings due to an attempt of formatting/decoration of the YouTube short link. With the usage of a base dictionary this causes a `KeyError` in the attempt to merge the list with a nonexistent one.

Tests
--------
```
test_misc.py::test_fix_splashes[case0-exp0] PASSED                                                                                                                                                                                                                     [  5%]
test_misc.py::test_fix_splashes[case1-exp1] PASSED                                                                                                                                                                                                                     [ 11%]
test_misc.py::test_fix_splashes[case2-exp2] PASSED                                                                                                                                                                                                                     [ 17%]
test_pseudo_ffprobe.py::test_probe[countdown.mp4-00:00:04.37] PASSED                                                                                                                                                                                                   [ 23%]
test_pseudo_ffprobe.py::test_probe["Ea-sy_Lemon_30_Second_-_Kevin_MacLeod.mp3"-00:00:31.29] PASSED                                                                                                                                                                     [ 29%]
test_pseudo_ffprobe.py::test_probe["Ecossaise in E-flat - Kevin MacLeod.mp3"-00:00:30.96] PASSED                                                                                                                                                                       [ 35%]
test_pseudo_ffprobe.py::test_album_art PASSED                                                                                                                                                                                                                          [ 41%]
test_pseudo_ffprobe.py::test_generate_tags[countdown.mp4] PASSED                                                                                                                                                                                                       [ 47%]
test_pyffmpeg.py::test_save_directory PASSED                                                                                                                                                                                                                           [ 52%]
test_pyffmpeg.py::test_convert[https://raw.githubusercontent.com/deuteronomy-works/pyffmpeg/master/tests/countdown.mp4-countdown.wav] PASSED                                                                                                                           [ 58%]
test_pyffmpeg.py::test_convert[https://raw.githubusercontent.com/deuteronomy-works/pyffmpeg/master/tests/sample_960x400_ocean_with_audio.flv-flv.mp4] PASSED                                                                                                           [ 64%]
test_pyffmpeg.py::test_convert[https://raw.githubusercontent.com/deuteronomy-works/pyffmpeg/master/tests/sample_960x400_ocean_with_audio.flv-flv.mp3] PASSED                                                                                                           [ 70%]
test_pyffmpeg.py::test_convert[https://raw.githubusercontent.com/deuteronomy-works/pyffmpeg/master/tests/sample_960x400_ocean_with_audio.flv-flv.wav] PASSED                                                                                                           [ 76%]
test_pyffmpeg.py::test_convert[https://raw.githubusercontent.com/deuteronomy-works/pyffmpeg/master/tests/sample_960x400_ocean_with_audio.flv-outs/flv.mp3] PASSED                                                                                                      [ 82%]
test_pyffmpeg.py::test_get_ffmpeg_bin PASSED                                                                                                                                                                                                                           [ 88%]
test_pyffmpeg.py::test_loglevel PASSED                                                                                                                                                                                                                                 [ 94%]
test_pyffmpeg.py::test_options PASSED
```
